### PR TITLE
fix(ts/bcdb): "rheology" => "rheometer"

### DIFF
--- a/scripts/typescript/src/bcdb/bcdb.ts
+++ b/scripts/typescript/src/bcdb/bcdb.ts
@@ -187,12 +187,19 @@ export class BCDBLoader {
             citation: [citation]
           });
 
-          const phase_method = row[Column.phase_method] ?? "";
+          // can be: "saxs", "tem", or "rheology"
+          let phase_method = row[Column.phase_method]?.toLowerCase() ?? "";
+
+          // The custom vocabulary does not allow "rheology"
+          // Replacing with "rheometer".
+          if(phase_method === "rheology")  phase_method = "rheometer";
+
           const condition: ICondition = {
             node: ["Condition"],
             key: "phase_method",
-            value: phase_method.toLowerCase(), // saxs, tem, rheology
+            value: phase_method, 
           };
+
           polymer.property.push({
             node: ["Property"],
             key: "microstructure_phase",


### PR DESCRIPTION
PR related to https://trello.com/c/ns5kt1Bw/79-bcdb-criptscripts-rheology-rheometer
Instead of using "rheology" we use the word "rheometry".
The JSON are up to date (https://drive.google.com/drive/folders/17AG2XVLixOB2XuDezbc9CdPiFQ7nLl37)