### PR TITLE
feat(typescript): improve validation tools

### DIFF
--- a/scripts/typescript/.gitignore
+++ b/scripts/typescript/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 out
+.env

--- a/scripts/typescript/README.md
+++ b/scripts/typescript/README.md
@@ -13,8 +13,9 @@ Will install this npm package and dependencies.
 
 # This project contains several ingestion scripts
 
-Note: scripts are still WIP.
+Disclaimer: these scripts do not rely on an SDK, that's why you should not consider to use them as a durable solution. We encourage you to rely on the SDK to write such scripts.
 
 - `afrl`: see [readme](src/afrl/README.md)
 - `bcdb`: see [readme](src/bcdb/README.md)
+- `pppdb`: see [readme](src/pppdb/README.md)
 - `rcbc`: see [readme](src/rcbc/README.md)

--- a/scripts/typescript/package-lock.json
+++ b/scripts/typescript/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@cript-web/bigsmiles-toolkit": "^1.0.5",
+        "cross-fetch": "^4.0.0",
         "csvtojson": "^2.0.10",
         "jsonstream-ts": "^1.3.6",
         "ts-node": "^10.9.1",
@@ -17,7 +19,22 @@
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
-        "@types/node": "^18.15.12"
+        "@tsconfig/node18": "^18.2.0",
+        "@types/node": "^18.15.12",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
+        "date-and-time": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.15.12"
+      }
+    },
+    "node_modules/@cript-web/bigsmiles-toolkit": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cript-web/bigsmiles-toolkit/-/bigsmiles-toolkit-1.0.5.tgz",
+      "integrity": "sha512-o17zeNiFvSyxVGKuXc3igIYOWlEozwVxLszcmbz9WLECaLfQFG83VgNVd4zTxwuOGgGmUvYP2OVyQj4KlcYpTQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -73,6 +90,12 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
+    "node_modules/@tsconfig/node18": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.0.tgz",
+      "integrity": "sha512-yhxwIlFVSVcMym3O31HoMnRXpoenmpIxcj4Yoes2DUpe+xCJnA7ECQP1Vw889V0jTt/2nzvpLQ/UuMYCd3JPIg==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
@@ -103,6 +126,39 @@
       "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/arg": {
@@ -151,6 +207,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/csvtojson": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
@@ -167,6 +231,12 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/date-and-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-3.0.0.tgz",
+      "integrity": "sha512-uuzXp/mvv6jEMLiP5QzERSQPzHqYnv9i8NZ8BS5kYeB2sakv74EewQiCS4Ahxwq3In+9fYZhGztuDHRVzIOkFQ==",
+      "dev": true
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -174,6 +244,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/frac": {
       "version": "1.1.2",
@@ -187,6 +263,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -240,6 +322,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ssf": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
@@ -266,6 +385,11 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
@@ -342,10 +466,33 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/wmf": {
       "version": "1.0.2",
@@ -393,6 +540,11 @@
     }
   },
   "dependencies": {
+    "@cript-web/bigsmiles-toolkit": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@cript-web/bigsmiles-toolkit/-/bigsmiles-toolkit-1.0.5.tgz",
+      "integrity": "sha512-o17zeNiFvSyxVGKuXc3igIYOWlEozwVxLszcmbz9WLECaLfQFG83VgNVd4zTxwuOGgGmUvYP2OVyQj4KlcYpTQ=="
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -440,6 +592,12 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
+    "@tsconfig/node18": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.0.tgz",
+      "integrity": "sha512-yhxwIlFVSVcMym3O31HoMnRXpoenmpIxcj4Yoes2DUpe+xCJnA7ECQP1Vw889V0jTt/2nzvpLQ/UuMYCd3JPIg==",
+      "dev": true
+    },
     "@types/node": {
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
@@ -459,6 +617,27 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
       "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="
+    },
+    "ajv": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      }
     },
     "arg": {
       "version": "4.1.3",
@@ -494,6 +673,14 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
+    "cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "requires": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "csvtojson": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/csvtojson/-/csvtojson-2.0.10.tgz",
@@ -504,10 +691,22 @@
         "strip-bom": "^2.0.0"
       }
     },
+    "date-and-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-3.0.0.tgz",
+      "integrity": "sha512-uuzXp/mvv6jEMLiP5QzERSQPzHqYnv9i8NZ8BS5kYeB2sakv74EewQiCS4Ahxwq3In+9fYZhGztuDHRVzIOkFQ==",
+      "dev": true
+    },
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "frac": {
       "version": "1.1.2",
@@ -518,6 +717,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
+    },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "json5": {
       "version": "2.2.3",
@@ -553,6 +758,26 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
+    "node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "ssf": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
@@ -573,6 +798,11 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "ts-node": {
       "version": "10.9.1",
@@ -616,10 +846,33 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "wmf": {
       "version": "1.0.2",

--- a/scripts/typescript/package.json
+++ b/scripts/typescript/package.json
@@ -5,14 +5,18 @@
   "main": "index.js",
   "scripts": {
     "build": "npx tsc",
+    "validate": "npx ts-node ./src/validate",
     "afrl": "npx ts-node ./src/afrl",
     "bcdb": "npx ts-node ./src/bcdb",
     "rcbc": "npx ts-node ./src/rcbc",
+    "pppdb": "npx ts-node ./src/pppdb",
     "test": "bash ./test.sh"
   },
   "author": "Bérenger Dalle-Cort, CRIPT, MIT",
   "license": "MIT",
   "dependencies": {
+    "@cript-web/bigsmiles-toolkit": "^1.0.5",
+    "cross-fetch": "^4.0.0",
     "csvtojson": "^2.0.10",
     "jsonstream-ts": "^1.3.6",
     "ts-node": "^10.9.1",
@@ -21,6 +25,13 @@
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
-    "@types/node": "^18.15.12"
+    "@tsconfig/node18": "^18.2.0",
+    "@types/node": "^18.15.12",
+    "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1",
+    "date-and-time": "^3.0.0"
+  },
+  "engines": {
+    "node": "^18.15.12"
   }
 }

--- a/scripts/typescript/src/bcdb/bcdb.ts
+++ b/scripts/typescript/src/bcdb/bcdb.ts
@@ -123,7 +123,6 @@ export class BCDBLoader {
           //   to reference the reference (haha)
           const citation: ICitation = {
             // uid: will be determined by CriptJSON serializer
-            name: `RCBC Citation ${index}`,
             node: ["Citation"],
             type: "extracted_by_human",
             reference,
@@ -136,7 +135,7 @@ export class BCDBLoader {
           const bigsmiles = row[Column.BigSMILES];
           const polymer: IMaterial = {
             node: ["Material"],
-            name: `RCBC Material ${index}`,
+            name: `BCDB_Material_${index}`,
             bigsmiles,
             notes: row[Column.notes]
           };
@@ -220,7 +219,7 @@ export class BCDBLoader {
           //-- Individual Block 1
           //   name and properties (Mn, Mw, D, N, f, ftot, w, rho)
           const block1: IMaterial = {
-            name: row[Column.name1],
+            name: `${polymer.name}_${row[Column.name1]}`,
             node: ["Material"],
             property: [
               {
@@ -294,7 +293,7 @@ export class BCDBLoader {
           //-- Individual Block 2
           //   name and properties (Mn, Mw, D, N, f, ftot, w, rho)
           const block2: IMaterial = {
-            name: row[Column.name2],
+            name: `${polymer.name}_${row[Column.name2]}`,
             node: ["Material"],
             property: [
               {

--- a/scripts/typescript/src/types/cript/Edges.ts
+++ b/scripts/typescript/src/types/cript/Edges.ts
@@ -1,0 +1,8 @@
+export type Edge = {
+    uid: string;
+}
+
+export type EdgeUUID = {
+    uuid: string;
+}
+  

--- a/scripts/typescript/src/types/cript/ICitation.ts
+++ b/scripts/typescript/src/types/cript/ICitation.ts
@@ -10,13 +10,10 @@ export type CitationType =
 
 export interface ICitation {
   readonly node: ['Citation'];
-
-  name: string;
   created_at?: string;
   updated_at?: string;
   model_version?: string;
   reference: IReference;
   uuid?: string;
-  // type: string;
   type: CitationType;
 }

--- a/scripts/typescript/src/types/cript/ICondition.d.ts
+++ b/scripts/typescript/src/types/cript/ICondition.d.ts
@@ -15,5 +15,5 @@ export interface ICondition {
   uncertainty_type?: string;
   unit?: string;
   uuid?: string;
-  value: string;
+  value: string | number | string[] | number[];
 }

--- a/scripts/typescript/src/types/cript/IMaterial.ts
+++ b/scripts/typescript/src/types/cript/IMaterial.ts
@@ -27,9 +27,13 @@ export interface IMaterial {
   identifier_count?: number;
   bigsmiles?: string;
   smiles?: string;
+  /** @deprecated, use chem_formula instead*/
   cas?: string;
   inchi?: string;
   inchi_key?: string;
   mol_form?: string;
   pubchem_cid?: number;  
+  chem_formula?: string;
+  // a.k.a CAS number
+  chemical_id?: string;
 }

--- a/scripts/typescript/src/types/cript/IProperty.ts
+++ b/scripts/typescript/src/types/cript/IProperty.ts
@@ -7,12 +7,12 @@ import { IMaterial } from "./IMaterial";
 export interface IProperty {
   readonly node: ['Property'];
   model_version?: string;
-  key?: string;
-  type?: string;
-  value?: string /* | number*/; // FIXME: backend does not allow number
-  unit?: string;
-  uncertainty?: string;
-  uncertainty_type?: string; //UncertainityType
+  key: string;
+  type: string;
+  value: string  | number;
+  unit: string | null;
+  uncertainty?: number;
+  uncertainty_type?: string;
   sample_preparation?: string;
   notes?: string;
   structure?: string;
@@ -21,7 +21,7 @@ export interface IProperty {
   condition?: ICondition[];
   data?: IData[];
   computation?: IComputation[];
-  citation?: ICitation[]; // IReference //ReferencePost
+  citation?: ICitation[];
   created_at?: string;
   updated_at?: string;  
   uuid?: string;

--- a/scripts/typescript/src/types/cript/IReference.ts
+++ b/scripts/typescript/src/types/cript/IReference.ts
@@ -13,6 +13,7 @@ export interface IReference {
   publisher?: string;
   volume?: string;
   issue?: string;
+  isbn?: string;
   issn?: string;
   arxiv_id?: string;
   pmid?: string;

--- a/scripts/typescript/src/types/cript/index.ts
+++ b/scripts/typescript/src/types/cript/index.ts
@@ -22,6 +22,7 @@ import { ISoftwareConfiguration } from './ISoftwareConfiguration';
 import { IVocabBase, IVocabIdentifier, IVocabProperty, IVocabQuantity, IVocab, IControlledVocabulary } from './IVocab';
 import { IQuantity } from './IQuantity';
 import { IEquipment } from './IEquipment';
+import { Edge, EdgeUUID } from './Edges';
 
 export type IPrimary =
   | ICollection
@@ -68,6 +69,8 @@ export type {
   IVocabProperty,
   IVocabQuantity,
   IControlledVocabulary,
+  Edge,
+  EdgeUUID,
 };
 
 export type Slug =

--- a/scripts/typescript/src/utilities/cript-graph-optimizer.ts
+++ b/scripts/typescript/src/utilities/cript-graph-optimizer.ts
@@ -1,0 +1,197 @@
+import { IIngredient, Edge } from "@cript";
+
+/**
+ * The role of this class is to reduce redundancy and ensure certain fields are properly defined.
+ * It is designed to work with any CRIPT object, but primarly intended to be use with an IProject.
+ * @example
+ * const my_project: IProject = { ... };
+ * const my_optimized_project = CriptGraphOptimizer.get_optimized(my_project);
+ */
+export class CriptGraphOptimizer {
+  enable_logs = false;
+  // reference counter to assign unique ids during a session
+  private next_uid = 0;
+  // Set of already optimized uid
+  private optimized_uid = new Set<string>();
+  // Unique names
+  private unique_names = new Set<string>();
+
+  private debug(...args: any) {
+    this.enable_logs && console.debug(args);
+  }
+  /**
+   * Ensure node has a uid, if not assign a new uid
+   */
+  private register_node(node: any): void {
+    if(node.uid) throw new Error("Node already has a uid, cannot be registered twice");
+
+    // ensure has a name
+    switch( node.node[0]) {
+      case 'Reference': // Reference has not a "name" it has a "title"   
+        if(!node.title) node.title = `${node.node[0]}_${this.next_uid++}`;
+        break;
+      default:   
+        if(!node.name) node.name = `${node.node[0]}_${this.next_uid++}`;
+        break;
+      case 'Ingredient': // Ingredient has no name and should not be reused
+      case 'Citation':   // Citation has no name and should not be reused        
+        return;
+    }
+
+    // ensure has a unique name/title
+    if( node.name) {
+      if( this.unique_names.has(node.name ) ) {
+        throw new Error(`The name '${node.name }' is already in use.`);
+      } else {
+        this.unique_names.add(node.name);
+        // temporary method for the backend to recognyze a reference
+        node.uid = `_:${node.name}`;
+      } 
+    }
+  };
+
+  /**
+   * Make an edge from a given node.
+   * note: and Edge only has a uid (which is NOT a uuid).
+   */
+  private make_edge = (node: any): Edge => {
+    if (node === undefined) throw new Error("Unable to use a reference from an undefined node");
+    if (node.uid === undefined) this.register_node(node);
+
+    // Ensure the node has model_version (but won't be included in the reference)
+    if (!node.model_version) {
+      this.debug(`-- node (uid: ${node.uid}) has no model_version, fixing it DONE`);
+      node.model_version = "1.0.0";
+    }
+
+    return {
+      uid: node.uid
+    };
+  };
+
+  /**
+   * Convert a given node property to edges.
+   */
+  private convert_to_edges = <T extends {[key: string]: any }, K extends keyof T>(node: T, key: K): void => {
+    const arr = node[key];
+    if(arr && arr.length !== 0) {
+      this.debug(`\tkey: ${key as string} ...`);
+      (node[key] as any[]) = arr.map(this.make_edge);
+      this.debug(`\tkey: ${key as string} DONE`);
+    }
+  }
+
+  private replacer(key: string, value: any): any {
+
+    /** optimize if value is a node */
+    const type: string | undefined = value?.node?.at(0);
+    if (type) {
+      
+      // create alias
+      const node = value;
+  
+      // return early if already optimized
+      switch (type) {
+        case 'Property':
+        case 'Condition':
+          // those nodes cannot be shared, no need to be registered
+          break
+        default:
+          // Ensure is registered
+          if (node.uid === undefined) this.register_node(node);                  
+      }
+      if(this.optimized_uid.has(node.uid)) return node; 
+      this.optimized_uid.add(node.uid);
+
+      this.debug(`-- Optimizing node (uid: "${node.uid}", type: "${type}", name: "${node.name}") ...`);
+
+      // specific case on per-type basis
+      switch (type) {
+        case "Inventory":
+          this.convert_to_edges(node, 'material');
+          break;
+
+        case 'Experiment':
+          // keep data
+          break;
+
+        case 'Property':
+        case 'Condition':
+          this.convert_to_edges(node, 'data');
+          this.convert_to_edges(node, 'computation');
+          break;
+
+        case 'Process':
+          if(node.ingredient) {
+            this.debug(`\tkey: ingredient ...`);
+            node.ingredient = node.ingredient?.map( (each: IIngredient, index: number) => {
+              return {
+               ...each,
+                material: each.material?.map(this.make_edge)
+              }
+            })
+            this.debug(`\tkey: ingredient DONE`);
+          }
+          this.convert_to_edges(node, 'data');
+          break;
+
+        case 'Project':
+            // we want the full collection, material and file arrays
+            break;
+      }
+    }
+
+    // Some keys always require to be references
+    switch (key) {
+      case "prerequisite_process":
+      case "waste":
+      case "product":
+      case "component":
+      case "input_data":
+      case "output_data":
+        if(value) {
+          this.debug(`\tkey: ${key} ...`);
+          value = value.map(this.make_edge);
+          this.debug(`\tkey: ${key} DONE`);
+        }
+        break;
+    }
+
+    if( type ) {
+      // create alias
+      const node = value;
+      this.debug(`-- Optimizing node (uid: "${node.uid}", type: "${type}", name: "${node.name}") DONE`);
+    }
+
+    return value;
+  };
+
+  private optimize_recursively(key: string, value: any): any {
+    if( value === null) {
+      return value;
+    }
+    if( typeof value === 'object' ) {
+      // Replaces each object's property recursively
+      for(let _key of Object.keys(value).values() ) {
+        value[_key] = this.optimize_recursively(_key, this.replacer(_key, value[_key]));
+      }
+      return value;
+    } 
+    return this.replacer(key, value);
+  }
+  /**
+   * Optimize a given cript object
+   * - uses Edge or EdgeUUID when possible
+   * - criptObject not changed (a deep copy is made)
+   */
+  get_optimized(criptObject: any): any {
+    this.reset_state();
+    const criptObjectCopy = structuredClone(criptObject); 
+    return this.optimize_recursively('', criptObjectCopy);
+  }
+
+  private reset_state() {
+    this.optimized_uid.clear();
+    this.unique_names.clear();
+  }
+}

--- a/scripts/typescript/src/utilities/cript-json.ts
+++ b/scripts/typescript/src/utilities/cript-json.ts
@@ -1,163 +1,16 @@
-import { IIngredient } from "@cript";
 import * as JSONStream from 'jsonstream-ts';
 import * as stream from 'stream';
-
-type Replacer = ((this: any, key: string, value: any) => any) | undefined;
-type NodeReference = { uid: string, node: [string]};
 
 /**
  * JSON serializer specific to CRIPT to reduce redundancy and ensure certain fields are properly defined
  */
 export class CriptJSON {
-  static logs = false;
-  // reference counter to assign unique ids during a session
-  private static next_uid = 0;
-  // Set of already optimized uid
-  private static optimized_uid = new Set<string>();
-
-  private static debug(...args: any) {
-    this.logs && console.debug(args);
-  }
-  /**
-   * Ensure node has a uid, if not assign a new uid
-   */
-  private static register_node(node: any): void {
-    if(node.uid) throw new Error("Node already has a uid, cannot be registered twice");
-
-    // ensure has a unique name
-    if(!node.name) {
-      node.name = `${node.node[0]}_${this.next_uid++}`;
-    } else {
-      node.name = `${node.name}_${this.next_uid++}`;
-    }
-    // temporary method for the backend to recognyze a reference
-    node.uid = `_:${node.name}`;
-  };
-
-  /**
-   * return a reference to the node instead of the full node
-   */
-  private static node_as_reference = (node: any): NodeReference => {
-    if (node === undefined) throw new Error("Unable to use a reference from an undefined node");
-    if (node.uid === undefined) this.register_node(node);
-
-    // Ensure the node has model_version (but won't be included in the reference)
-    if (!node.model_version) {
-      this.debug(`-- node (uid: ${node.uid}) has no model_version, fixing it DONE`);
-      node.model_version = "1.0.0";
-    }
-
-    return {
-      uid: node.uid,
-      node: node.node,
-    };
-  };
-
-  private static array_property_as_reference = <T extends {[key: string]: any }, K extends keyof T>(node: T, key: K): void => {
-    const arr = node[key];
-    if(arr && arr.length !== 0) {
-      this.debug(`\tkey: ${key as string} ...`);
-      (node[key] as any[]) = arr.map(this.node_as_reference);
-      this.debug(`\tkey: ${key as string} DONE`);
-    }
-  }
-
-  private static replacer: Replacer = (key: string, value: any): any => {
-
-    /** optimize if value is a node */
-    const type: string | undefined = value?.node?.at(0);
-    if (type) {
-      
-      // create alias
-      const node = value;
-  
-      // return early if already optimized
-      switch (type) {
-        case 'Property':
-        case 'Condition':
-          // those nodes cannot be shared, no need to be registered
-          break
-        default:
-          // Ensure is registered
-          if (node.uid === undefined) this.register_node(node);                  
-      }
-      if(this.optimized_uid.has(node.uid)) return node; 
-      this.optimized_uid.add(node.uid);
-
-      this.debug(`-- Optimizing node (uid: "${node.uid}", type: "${type}", name: "${node.name}") ...`);
-
-      // specific case on per-type basis
-      switch (type) {
-        case "Inventory":
-          this.array_property_as_reference(node, 'material');
-          break;
-
-        case 'Experiment':
-          // keep data
-          break;
-
-        case 'Property':
-        case 'Condition':
-          this.array_property_as_reference(node, 'data');
-          this.array_property_as_reference(node, 'computation');
-          break;
-
-        case 'Process':
-          if(node.ingredient) {
-            this.debug(`\tkey: ingredient ...`);
-            node.ingredient = node.ingredient?.map( (each: IIngredient, index: number) => {
-              return {
-               ...each,
-                material: each.material?.map(this.node_as_reference)
-              }
-            })
-            this.debug(`\tkey: ingredient DONE`);
-          }
-          this.array_property_as_reference(node, 'data');
-          break;
-
-        case 'Material':
-          this.array_property_as_reference(node, 'component');
-          break;
-
-        case 'Project':
-            // we want the full collection, material and file arrays
-            break;
-      }
-    }
-
-    // Some keys always require to be references
-    switch (key) {
-      case "prerequisite_process":
-      case "waste":
-      case "product":
-      case "component":
-      case "input_data":
-      case "output_data":
-        if(value) {
-          this.debug(`\tkey: ${key} ...`);
-          value = value.map(this.node_as_reference);
-          this.debug(`\tkey: ${key} DONE`);
-        }
-        break;
-    }
-
-    if( type ) {
-      // create alias
-      const node = value;
-      this.debug(`-- Optimizing node (uid: "${node.uid}", type: "${type}", name: "${node.name}") DONE`);
-    }
-
-    return value;
-  };
-
   /**
    * Stringify a value as a string using JSON.stringify
    * Works well on small objects, use stringifyAsStream in case you have issues.
    */
   static stringify(value: any, space: string | number | undefined = undefined): string {
-    this.optimized_uid.clear();
-    return JSON.stringify(value, this.replacer, space);
+    return JSON.stringify(value, null, space);
   }
 
   /**
@@ -166,12 +19,12 @@ export class CriptJSON {
    */
   static stringifyAsStream(outStream: stream.Writable, value: Record<string, any>, space: string | number | undefined = undefined,): void {
 
-    this.optimized_uid.clear();
+    console.warn(`It looks like this function has issues, prefer using stringify(). \n It appeared that the JSON is uncomplete, needs to be investigated. \n The initial purpose of this function was to use streams insted of strings, but it is not necessary for small sized JSON.`)
     
     // hack (install)
     // JSONStream does not allow to specify a replacer (like JSON.stringify offers)
     const stringify_original =  JSON.stringify;
-    JSON.stringify = (value: any, replacer, indent) => stringify_original(value, this.replacer, indent)
+    JSON.stringify = (value: any, replacer, indent) => stringify_original(value, null, indent)
 
     // start to stream an object
     const transformStream: stream.Transform = JSONStream.stringifyObject('{', ',', '}', space);

--- a/scripts/typescript/src/utilities/cript-project-validator.ts
+++ b/scripts/typescript/src/utilities/cript-project-validator.ts
@@ -1,0 +1,68 @@
+import { IProject } from "@cript";
+import Ajv, { AnySchemaObject, Options } from "ajv";
+import addFormats from "ajv-formats"
+import fetch from "cross-fetch";
+
+/**
+ * Simple class to validate a CRIPT Project
+ */
+export class CriptProjectValidator {
+    
+    private ajv: Ajv;
+
+    constructor(options: Options = {
+        allErrors: true,
+    }) {
+        this.ajv = new Ajv(options);
+        addFormats(this.ajv); // for "date-time"
+    }
+
+    private async fetchSchema(): Promise<AnySchemaObject> {
+        const url = process.env.CRIPT_SCHEMA_URL;
+        if(!url) {
+            throw new Error(`CRIPT_SCHEMA_URL is undefined. Define it in your .env file`)
+        }
+        
+        let response: Response;
+        try {
+            response = await fetch(url);
+        } catch(error: any) {
+            throw new Error(`Unable to fetch schema from '${url}'`);
+        }
+
+        if(!response.ok) throw new Error(`Unable to fetch schema from '${url}', reponse: ${JSON.stringify(response)}`);
+        console.log(`Using schema '${url}'`);
+
+        const schema = (await response.json()).data;
+        return schema;
+    }
+
+    async validate(type: 'ProjectPost' | 'ProjectPatch', project: IProject): Promise<boolean> {
+        let schema: AnySchemaObject;
+        try {
+            schema = await this.fetchSchema();
+        } catch( error: any ) {
+            console.error(`Unable to validate, fetchSchema failed. Reason: ${error.message}, ${error.stack}`)
+            return false;
+        }
+
+        schema['$ref'] = `#/$defs/${type}`;
+        return Boolean(await this.ajv.validate(schema, project));
+    }
+
+    logErrors() {
+        const errors = this.errorsAsString();
+        if(errors.length === 0) {
+            return console.log(`No error found.`)
+        }
+        console.error(errors);
+    }
+
+    errorsAsString() {
+        if ( !this.ajv.errors ) {
+            return '';
+        }
+        const errorsAsJSONString = JSON.stringify(this.ajv.errors, null, '  ');
+        return `${errorsAsJSONString}\n${this.ajv.errors?.length} error(s) found, see log above.}`;
+    }
+}

--- a/scripts/typescript/src/utilities/index.ts
+++ b/scripts/typescript/src/utilities/index.ts
@@ -2,3 +2,6 @@ export * from './cript-json';
 export * from './output_dir_path';
 export * from './write_json_helper';
 export * from './finishedAsync';
+export * from './cript-project-validator';
+export * from './logger';
+export * from './cript-graph-optimizer';

--- a/scripts/typescript/src/utilities/logger.ts
+++ b/scripts/typescript/src/utilities/logger.ts
@@ -1,0 +1,93 @@
+import { Readable, Writable } from "stream";
+import date from "date-and-time";
+
+/**
+ * Log levels from low to high verbosity
+ */
+export enum LogLevel {
+  ERROR = 0,
+  WARNING,  
+  /** Is usually the default */
+  INFO,
+  DEBUG,
+}
+
+export type LoggerOptions = {
+  /** logs output stream (ex: a file stream or stdout) */
+  outstream: Writable;
+  /** Default verbosity level for the logs */
+  verbosity: LogLevel;
+  /** If true, timestamp will be added to the logs */
+  timestamp: boolean;
+};
+
+/**
+ * Simple logger with two main functionnalitites:
+ * - ajustable verbosity (@see LogLevel)
+ * - uses Readable stream insead of console (performance is better)
+ * - output can be redirected to any writable stream (ex: logStream.pipe(<writable-stream>).
+ */
+export class Logger {
+
+  /** A prefix to insert before any log */
+  prefix: string | null;
+  /** To adjust the verbosity (ex: set it to LogLevel.ERR to skip warnings, messages, and debug) */
+  verbosity: LogLevel;
+  /**
+   * Readable stream to push the logs into, redirect it using pipe()
+   * ex: logger.logStream.pipe(process.stdout)
+   */
+  readonly logStream: Readable;
+  /** If true, inserts the timestamp in the logs */
+  private timestamp_enabled: boolean;
+
+  constructor(options: LoggerOptions) {
+    this.verbosity = options.verbosity;
+    this.logStream = new Readable({
+      read: () => {},
+    });
+    this.logStream.pipe(options.outstream);
+    this.prefix = null;
+    this.timestamp_enabled = options.timestamp;
+  }
+
+  // shorthand for _log(level, ...)
+
+  debug(...args: string[])   {this._log(LogLevel.DEBUG, ...args);}
+  info(...args: string[])    {this._log(LogLevel.INFO, ...args);}
+  warning(...args: string[]) {this._log(LogLevel.WARNING, ...args);}
+  error(...args: string[])   {this._log(LogLevel.ERROR, ...args);}
+
+  /**
+   * Log using a given level, message might be ignored if level is too high compare to current verbosity.
+   * Message are formatted like:
+   * "[timestamp] <VERBOSITY> <prefix><arg0><arg1>...<argn>""
+   */
+  _log(level: LogLevel, ...args: string[]) {
+    if (level > this.verbosity) return;
+
+    if(this.timestamp_enabled) {
+      const now = new Date();
+      const day = date.format(now, 'YYYY/MM/DD');
+      const time = date.format(now, 'HH:mm:ss A');
+      const gmt = date.format(now, '[GMT]Z');
+      this.logStream.push(`${day} ${time} ${gmt} `)
+    }
+    
+    switch (level) {
+      case LogLevel.ERROR:   this.logStream.push('[ERR 🚩] '); break;
+      case LogLevel.WARNING: this.logStream.push('[WRN ⚠️] '); break;
+      case LogLevel.INFO:    this.logStream.push('[INFO  ] '); break;
+      case LogLevel.DEBUG:   this.logStream.push('[DEBUG ] '); break;
+      default:
+        const will_fail_at_compile_time: never = level; // for static check
+        throw new Error(`Not handled case: ${will_fail_at_compile_time}`); // for runtime check
+    }
+
+    if (this.prefix !== null) {
+      this.logStream.push(this.prefix);
+    }
+    args.forEach((v) => this.logStream.push(v));
+    this.logStream.push("\n");
+  }
+}

--- a/scripts/typescript/src/utilities/write_json_helper.ts
+++ b/scripts/typescript/src/utilities/write_json_helper.ts
@@ -9,10 +9,15 @@ import { finishedAsync } from '@utilities';
  * 
  * This function is not synchronous and required to be awaied before program exits
  */
-export function write_json_helper(value: any, filename: string, mode: 'human-readable' | 'minified' = 'human-readable'): Promise<any> {
+export function write_json_helper(
+    value: any,
+    output_file_name: string,
+    mode: 'human-readable' | 'minified' = 'human-readable',
+    method: 'as_stream' | 'as_string' = 'as_string'
+    ): Promise<any> {
     
     // prepare output file path
-    const output_filename = mode === 'minified' ? `${filename}.min.json` : `${filename}.json`;
+    const output_filename = mode === 'minified' ? `${output_file_name}.min.json` : `${output_file_name}.json`;
     const output_filepath = path.resolve(output_dir_path, output_filename);
 
     // make output directory path (if missing)
@@ -26,8 +31,14 @@ export function write_json_helper(value: any, filename: string, mode: 'human-rea
 
     // Transform: value => JSON => file
     const space = mode === 'minified' ? undefined : 2;
-    CriptJSON.logs = false; // heavy logging
-    CriptJSON.stringifyAsStream(file_stream, value, space);
+
+    if( method === 'as_stream' ) {
+        console.warn(`as_stream is known to have issues, see CriptJSON.stringifyAsStream() implem.`);
+        CriptJSON.stringifyAsStream(file_stream, value, space);
+    } else { // 'as_string'
+        const jsonAsString = CriptJSON.stringify(value, space);
+        file_stream.write( jsonAsString );
+    }    
 
     return finishedAsync(file_stream);
 }

--- a/scripts/typescript/src/validate/README.md
+++ b/scripts/typescript/src/validate/README.md
@@ -1,0 +1,7 @@
+# Validate
+
+This script is a cli to validate a given project JSON from against CRIPT schema.
+
+Requires to have CRIPT_SCHEMA_URM environment variable set.
+
+Usage: npm run validate absolute/or/relative/path/to/project.json

--- a/scripts/typescript/src/validate/index.ts
+++ b/scripts/typescript/src/validate/index.ts
@@ -1,0 +1,56 @@
+/**
+ * The purpose of this script is to valida a given project JSON
+ */
+
+import { IProject } from "@cript";
+import { CriptProjectValidator } from "@utilities";
+import { readFileSync } from "fs";
+import { isAbsolute, resolve } from "path";
+import { argv, exit } from "process";
+
+(async() => {
+
+    const project_path = argv[2];
+
+    if( !project_path ) {
+        console.error('Missing argument, an absolute file path is expected.');
+        print_help();
+        exit(1);
+    }
+
+    console.log('project_path', project_path);
+
+    const validator = new CriptProjectValidator();
+    try {
+        const absolute_project_path = isAbsolute(project_path) ? project_path : resolve(__dirname, project_path);
+        console.log('Absolute file path is:', absolute_project_path);
+
+        console.log(`Loading file ... `);
+        const buffer = readFileSync(absolute_project_path);
+        console.log(`OK\n`);
+
+        console.log(`Parsing file ... `);
+        const project = JSON.parse(buffer.toString()) as IProject;
+        console.log(`OK\n`);
+
+        console.log(`Validating file ... `);
+        const is_valid = await validator.validate('ProjectPost', project);
+        console.log(`${ is_valid ? 'OK' : 'ERROR!' }\n`);
+
+        if( !is_valid ) {
+            validator.logErrors();
+            exit(1);
+        }
+
+    } catch (error: any) {
+        console.error(`Unable to load file, reason:\n`, error.message, error.stack);
+        exit(1);
+    }
+
+    exit(0);
+})();
+
+
+function print_help() {
+    console.log(`Usage: npm run validate absolute/or/relative/path/to/my/project.json`);
+}

--- a/scripts/typescript/tsconfig.json
+++ b/scripts/typescript/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "display": "Node 18",
+  "_version": "18.15.12",
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
@@ -11,8 +14,8 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "ESNext",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["es2023"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -23,15 +26,14 @@
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "Node16",                                /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    //"baseUrl": "./",                                   /* Specify the base directory to resolve non-relative module names. */
+    "moduleResolution": "NodeNext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "baseUrl": "./src",                                   /* Specify the base directory to resolve non-relative module names. */
     "paths": {                                           /* Specify a set of entries that re-map imports to additional lookup locations. */
-      "@cript": ["./src/types/cript", "./src/types/cript*"],
-      "@utilities": ["./src/utilities", "./src/utilities*"]
+      "@cript": ["types/cript", "types/cript*"],
+      "@utilities": ["utilities", "utilities*"]
     },                                      
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
@@ -86,7 +88,7 @@
 
     /* Type Checking */
     "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    "noImplicitAny": false,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */


### PR DESCRIPTION
This PR contains changes relative to typings and utilities for the whole typescript folder.
I rewrote the history of #20  to have utilities commits at the base of the branch, this branch contains only those general changes.

The main changes are:
- add `CriptGraphOptimizer` to simplify a given Cript object (in my case always an IProject) by adding Edges and EdgeUUIDs, and assigning local uids to nodes.
- add `CriptProjectValidator` to run validation against a DB schema (`CRIPT_API_SCHEMA `must be defined as env var)

I saw few things messy in this PR,  like mentions to pppdb scripts in the readme and scripts, sorry about this, but I had to do this quickly to be able to advance on any ingestion script faster. This way most of the pppdb's work is isolated in feat/pppdb.

This branch should be reviewed before #20 .