### PR TITLE
hack(bcdb): comment 'method' on every single property

### DIFF
--- a/scripts/typescript/src/bcdb/bcdb.ts
+++ b/scripts/typescript/src/bcdb/bcdb.ts
@@ -178,7 +178,7 @@ export class BCDBLoader {
             key: "mw_n",
             type: 'value',
             value: row[Column.Mn],
-            method: row[Column.Mn_method],
+            //method: row[Column.Mn_method], TODO: fix data to match with vocab
             unit: "g/mol",
             condition: [temperature],
             citation,
@@ -188,7 +188,7 @@ export class BCDBLoader {
             key: "mw_w",
             type: 'value',
             value: row[Column.Mw],
-            method: row[Column.Mw_method],
+            //method: row[Column.Mw_method], TODO: fix data to match with vocab
             unit: "g/mol",
             condition: [temperature],
             citation,
@@ -198,7 +198,7 @@ export class BCDBLoader {
             key: "mw_d",
             type: 'value',
             value: row[Column.D],
-            method: row[Column.D_method],
+            //method: row[Column.D_method], TODO: fix data to match with vocab
             unit: "g/mol",
             condition: [temperature],
             citation,
@@ -208,7 +208,7 @@ export class BCDBLoader {
             key: "invariant_degree_of_polymerization",
             type: 'value',
             value: row[Column.N],
-            method: row[Column.N_method],
+            //method: row[Column.N_method], TODO: fix data to match with vocab
             condition: [temperature],
             citation,
             unit: null,          
@@ -227,7 +227,7 @@ export class BCDBLoader {
             type: 'value',
             notes: "phase1",
             value: row[Column.PHASE1],
-            method: phase_method,
+            //method: phase_method, TODO: fix data to match with vocab
             citation,
             unit: null,
           });
@@ -237,7 +237,7 @@ export class BCDBLoader {
             notes: "phase2",
             type: 'value',
             value: row[Column.PHASE2],
-            method: phase_method,
+            //method: phase_method, TODO: fix data to match with vocab
             citation,
             unit: null,
           });
@@ -255,7 +255,7 @@ export class BCDBLoader {
             key: "mw_w",
             type: 'value',
             value: row[Column.Mw1],
-            method: row[Column.Mw1_method],
+            //method: row[Column.Mw1_method], TODO: fix data to match with vocab
             unit: "g/mol",
             citation,
           });
@@ -264,7 +264,7 @@ export class BCDBLoader {
             key: "mw_d",
             type: 'value',
             value: row[Column.D1],
-            method: row[Column.D1_method],
+            //method: row[Column.D1_method], TODO: fix data to match with vocab
             unit: "g/mol",
             citation,
           });
@@ -273,7 +273,7 @@ export class BCDBLoader {
             key: "invariant_degree_of_polymerization",
             type: 'value',
             value: row[Column.N1],
-            method: row[Column.N1_method],
+            //method: row[Column.N1_method], TODO: fix data to match with vocab
             unit: null,
             citation,
           });
@@ -282,7 +282,7 @@ export class BCDBLoader {
             key: "conc_vol_fraction",
             type: 'value',
             value: row[Column.f1],
-            method: row[Column.f1_method],
+            //method: row[Column.f1_method], TODO: fix data to match with vocab
             unit: null,
             citation,
           });
@@ -291,7 +291,7 @@ export class BCDBLoader {
             key: "conc_vol_fraction",
             type: 'value',
             value: row[Column.ftot1],
-            method: row[Column.ftot1_method],
+            // method: row[Column.ftot1_method], TODO: fix data to match with vocab
             unit: null,
             citation,
           });
@@ -300,7 +300,7 @@ export class BCDBLoader {
             key: "conc_mass_fraction",
             type: 'value',
             value: row[Column.w1],
-            method: row[Column.w1_method],
+            //method: row[Column.w1_method], TODO: fix data to match with vocab
             unit: null,
             citation,
           });
@@ -309,7 +309,7 @@ export class BCDBLoader {
             key: "density",
             type: 'value',
             value: row[Column.rho1],
-            method: row[Column.rho1_method],
+            //method: row[Column.rho1_method], TODO: fix data to match with vocab
             unit: "g/mL",
             citation,
           });
@@ -318,7 +318,7 @@ export class BCDBLoader {
             key: "microstructure_phase",
             type: 'value',
             value: `${row[Column.PHASE1]},${row[Column.PHASE2]}`,
-            method: row[Column.rho1_method],
+            // method: row[Column.rho1_method], TODO: fix data to match with vocab
             unit: "g/mL",
             citation,
           })
@@ -356,7 +356,7 @@ export class BCDBLoader {
             key: "invariant_degree_of_polymerization",
             type: 'value',
             value: row[Column.N2],
-            method: row[Column.N2_method],
+            // method: row[Column.N2_method], TODO: fix data to match with vocab
             unit: null,
             citation,
           });
@@ -365,7 +365,7 @@ export class BCDBLoader {
             key: "conc_vol_fraction",
             type: 'value',
             value: row[Column.f2],
-            method: row[Column.f2_method],
+            //method: row[Column.f2_method], TODO: fix data to match with vocab
             unit: null,
             citation,
           });
@@ -374,7 +374,7 @@ export class BCDBLoader {
             key: "conc_vol_fraction",
             type: 'value',
             value: row[Column.ftot2],
-            method: row[Column.ftot2_method],
+            //method: row[Column.ftot2_method], TODO: fix data to match with vocab
             unit: null,
             citation,
           });
@@ -383,7 +383,7 @@ export class BCDBLoader {
             key: "conc_mass_fraction",
             type: 'value',
             value: row[Column.w2],
-            method: row[Column.w2_method],
+            // method: row[Column.w2_method], TODO: fix data to match with vocab
             unit: null,
             citation,
           })
@@ -392,7 +392,7 @@ export class BCDBLoader {
             key: "density",
             type: 'value',
             value: row[Column.rho2],
-            method: row[Column.rho2_method],
+            //method: row[Column.rho2_method], TODO: fix data to match with vocab
             unit: "g/mL",
             citation,
           })

--- a/scripts/typescript/src/bcdb/index.ts
+++ b/scripts/typescript/src/bcdb/index.ts
@@ -17,7 +17,7 @@ import { BCDBLoader } from "./bcdb";
 
   const loader = new BCDBLoader({ logger: {
     outstream: logStream, // We use a stream to reduce considerably CPU usage compared to console.log|warn|error|info() which flushes after each call.
-    verbosity: LogLevel.DEBUG, // Consider reducing the verbosity when needed, it will reduce log output
+    verbosity: LogLevel.INFO, // Consider reducing the verbosity when needed, it will reduce log output
     timestamp: true, // Not required, but usefull to figure out when a problem occured.
   }});
 

--- a/scripts/typescript/src/pppdb/pppdb.ts
+++ b/scripts/typescript/src/pppdb/pppdb.ts
@@ -11,7 +11,7 @@ import { resolve } from "path";
 import { ICitation, ICollection, ICondition, IMaterial, IProject, IProperty, IReference } from "@cript";
 import { Chi, Method, Polymer, PubChemCASResponse, PubChemResponse as PubChemPropertyResponse, Solvent } from "./types";
 import { molfile_to_bigsmiles } from "@cript-web/bigsmiles-toolkit";
-import { CriptValidator, Logger, LogLevel, LoggerOptions, CriptGraphOptimizer } from "@utilities";
+import { CriptValidator, Logger, LogLevel, LoggerOptions, CriptGraphOptimizer, OptimizedProject } from "@utilities";
 import { Other } from "./types/sheets/others";
 import { fetch } from "cross-fetch";
 export class PPPDBLoader {
@@ -102,7 +102,7 @@ export class PPPDBLoader {
       molfile_dir: string,
     };
     row_limit: number;
-  }): Promise<IProject> {
+  }): Promise<OptimizedProject> {
     this.logger.prefix = null;
     this.logger.info(`PPPDB.load() ...`);
     this.logger.debug(`Reset state`);
@@ -531,7 +531,7 @@ export class PPPDBLoader {
 
     // Validate the project using DB schema
     this.logger.info(`Project validation ...`);      
-    const project_is_valid = this.validator.validate('ProjectPost', optimized_project);      
+    const project_is_valid = this.validator.validate('ProjectPost', optimized_project.project);      
     if( project_is_valid ) {
       this.logger.info(`Project validation: SUCCEEDED!`);
     } else {

--- a/scripts/typescript/src/utilities/cript-graph-optimizer.ts
+++ b/scripts/typescript/src/utilities/cript-graph-optimizer.ts
@@ -200,9 +200,9 @@ export class CriptGraphOptimizer {
 
       case "citation":
         // Reference will be moved to the shared_references, and a simple Edge will be set for node.reference
-        if (value) value = value.map( v => {
-          v.reference = this.make_edge(value);
-          return v
+        if (value) value = value.map( _citation => {
+          _citation.reference = this.make_edge(_citation.reference);
+          return _citation;
         })
         break;
     }

--- a/scripts/typescript/src/utilities/cript-graph-optimizer.ts
+++ b/scripts/typescript/src/utilities/cript-graph-optimizer.ts
@@ -234,18 +234,18 @@ export class CriptGraphOptimizer {
    * - uses Edge or EdgeUUID when possible
    * - criptObject not changed (a deep copy is made)
    */
-  get_optimized(criptObject: IProject): OptimizedProject {
+  get_optimized(project: IProject): OptimizedProject {
     this.reset_state();
 
     // Generate an optimized structure
-    const criptObjectCopy = structuredClone(criptObject);
+    const _project = this.optimize_recursively('', structuredClone(project));
+
     const result: OptimizedProject = {
       shared: {
-        reference: [...this.shared_references.values()],
+        reference: [...this.shared_references.values()]
       },
-      project: this.optimize_recursively('', criptObjectCopy)
+      project: _project
     }
-
     // Warn user in case no references are present
     if( result.shared.reference.length === 0 ) {
       this.debug(`No shared references found`);

--- a/scripts/typescript/src/utilities/cript-graph-optimizer.ts
+++ b/scripts/typescript/src/utilities/cript-graph-optimizer.ts
@@ -1,11 +1,27 @@
-import { IIngredient, Edge } from "@cript";
+import { IIngredient, Edge, IReference, IProject } from "@cript";
 
+/**
+ * Optimized project structure.
+ * 
+ * Why? Some shared nodes cannot be stored in a project (Reference),
+ * and need to be inserted prior to the project to be reused.
+ */
+export type OptimizedProject = {
+  // Unique nodes shared by the project
+  shared: {
+    reference: IReference[];
+  },
+  // Project referencing children with Edge or EdgeUUID
+  project: IProject;
+}
+ 
 /**
  * The role of this class is to reduce redundancy and ensure certain fields are properly defined.
  * It is designed to work with any CRIPT object, but primarly intended to be use with an IProject.
  * @example
  * const my_project: IProject = { ... };
- * const my_optimized_project = CriptGraphOptimizer.get_optimized(my_project);
+ * const optimized = CriptGraphOptimizer.get_optimized(my_project);
+ * // optimized.project
  */
 export class CriptGraphOptimizer {
   enable_logs = false;
@@ -15,6 +31,9 @@ export class CriptGraphOptimizer {
   private optimized_uid = new Set<string>();
   // Unique names
   private unique_names = new Set<string>();
+  // They cannot be stored directly in a project to be reused.
+  // They should be ingested first, and referenced using Edge or EdgeUUID by the Citations.
+  private shared_references = new Map<string, IReference>();
 
   private debug(...args: any) {
     this.enable_logs && console.debug(args);
@@ -25,13 +44,14 @@ export class CriptGraphOptimizer {
   private register_node(node: any): void {
     if(node.uid) throw new Error("Node already has a uid, cannot be registered twice");
 
+    const type = node.node[0];
     // ensure has a name
-    switch( node.node[0]) {
+    switch( type ) {
       case 'Reference': // Reference has not a "name" it has a "title"   
-        if(!node.title) node.title = `${node.node[0]}_${this.next_uid++}`;
+        if(!node.title) node.title = `${type}_${this.next_uid++}`;
         break;
       default:   
-        if(!node.name) node.name = `${node.node[0]}_${this.next_uid++}`;
+        if(!node.name) node.name = `${type}_${this.next_uid++}`;
         break;
       case 'Ingredient': // Ingredient has no name and should not be reused
       case 'Citation':   // Citation has no name and should not be reused        
@@ -39,14 +59,31 @@ export class CriptGraphOptimizer {
     }
 
     // ensure has a unique name/title
-    if( node.name) {
-      if( this.unique_names.has(node.name ) ) {
-        throw new Error(`The name '${node.name }' is already in use.`);
+    const name_or_title =  node.name ??  node.title;
+    if( name_or_title ) {
+      if( this.unique_names.has(name_or_title) ) {
+        throw new Error(`The name '${name_or_title}' is already in use.`);
       } else {
-        this.unique_names.add(node.name);
+        this.unique_names.add(name_or_title);
         // temporary method for the backend to recognyze a reference
-        node.uid = `_:${node.name}`;
+        node.uid = `_:${name_or_title}`;
       } 
+    }
+
+    // ensure has a name
+    switch( type) {
+      case 'Reference': // Reference has not a "name" it has a "title"   
+        if(!node.title) node.title = `${type}_${this.next_uid++}`;
+        // References must be stored in a shared container, outside of the project (which cannot handle them by design)
+        if( this.shared_references.has(node.uid)) throw new Error(`Reference already exists in shared_references (uid: '${node.uid}')`);
+        this.shared_references.set(node.uid, node);
+        break;
+      default:   
+        if(!node.name) node.name = `${type}_${this.next_uid++}`;
+        break;
+      case 'Ingredient': // Ingredient has no name and should not be reused
+      case 'Citation':   // Citation has no name and should not be reused        
+        return;
     }
   };
 
@@ -101,7 +138,7 @@ export class CriptGraphOptimizer {
           if (node.uid === undefined) this.register_node(node);                  
       }
       if(this.optimized_uid.has(node.uid)) return node; 
-      this.optimized_uid.add(node.uid);
+      if(node.uid) this.optimized_uid.add(node.uid);
 
       this.debug(`-- Optimizing node (uid: "${node.uid}", type: "${type}", name: "${node.name}") ...`);
 
@@ -143,6 +180,9 @@ export class CriptGraphOptimizer {
 
     // Some keys always require to be references
     switch (key) {
+      
+      // Arrays
+      
       case "prerequisite_process":
       case "waste":
       case "product":
@@ -154,6 +194,16 @@ export class CriptGraphOptimizer {
           value = value.map((v: any ) => this.make_edge(v));
           this.debug(`\tkey: ${key} DONE`);
         }
+        break;
+      
+      // Single value
+
+      case "citation":
+        // Reference will be moved to the shared_references, and a simple Edge will be set for node.reference
+        if (value) value = value.map( v => {
+          v.reference = this.make_edge(value);
+          return v
+        })
         break;
     }
 
@@ -184,14 +234,29 @@ export class CriptGraphOptimizer {
    * - uses Edge or EdgeUUID when possible
    * - criptObject not changed (a deep copy is made)
    */
-  get_optimized(criptObject: any): any {
+  get_optimized(criptObject: IProject): OptimizedProject {
     this.reset_state();
-    const criptObjectCopy = structuredClone(criptObject); 
-    return this.optimize_recursively('', criptObjectCopy);
+
+    // Generate an optimized structure
+    const criptObjectCopy = structuredClone(criptObject);
+    const result: OptimizedProject = {
+      shared: {
+        reference: [...this.shared_references.values()],
+      },
+      project: this.optimize_recursively('', criptObjectCopy)
+    }
+
+    // Warn user in case no references are present
+    if( result.shared.reference.length === 0 ) {
+      this.debug(`No shared references found`);
+    }
+
+    return result;
   }
 
   reset_state() {
     this.optimized_uid.clear();
     this.unique_names.clear();
+    this.shared_references.clear();
   }
 }

--- a/scripts/typescript/src/utilities/cript-validator.ts
+++ b/scripts/typescript/src/utilities/cript-validator.ts
@@ -42,7 +42,7 @@ export class CriptValidator {
         return true;
     }
 
-    private async fetchSchema(url: string, cache: 'r' | 'rw' | 'w' = 'rw'): Promise<AnySchemaObject> {
+    private async fetchSchema(url: string): Promise<AnySchemaObject> {
 
         let response: Response;
         try {


### PR DESCRIPTION
The graph optimizer now try to reuse references instead of having copies.
The JSON output now contains the shared references in addition to the exported project.
The "method" fields have been commented out for every properties, this is to by-pass a vocabulary/data mismatch by lack of time to investigate it.